### PR TITLE
Don't list errors that are suppressed

### DIFF
--- a/sarif-to-markdown.csx
+++ b/sarif-to-markdown.csx
@@ -94,7 +94,8 @@ void CreateResult(string filePath, StringBuilder sb, string fileName, ICollectio
             {
                 var tool = securityScan.Runs.FirstOrDefault()?.Tool;
                 foreach (var result in run.Results.Where(result =>
-                             (!onlyErrors || result.Level == "error") && !(result.Suppressions != null && result.Suppressions.Any())))
+                             (!onlyErrors || result.Level == "error") &&
+                             !(result.Suppressions != null && result.Suppressions.Any())))
                 {
                     sb.Append(CreateResultInfo(result, tool));
                 }
@@ -122,7 +123,8 @@ bool ShouldProcess(bool onlyErrors, SecurityScan securityScan1)
 
     return !onlyErrors
         ? runs.Any(run => run.Results.Any())
-        : runs.Any(run => run.Results.Any(result => result.Level == "error" && !result.Suppressions.Any()));
+        : runs.Any(run => run.Results.Any(result =>
+            result.Level == "error" && !(result.Suppressions != null && result.Suppressions.Any())));
 }
 
 string CreateResultInfo(Result result, Tool tool)

--- a/sarif-to-markdown.csx
+++ b/sarif-to-markdown.csx
@@ -94,7 +94,7 @@ void CreateResult(string filePath, StringBuilder sb, string fileName, ICollectio
             {
                 var tool = securityScan.Runs.FirstOrDefault()?.Tool;
                 foreach (var result in run.Results.Where(result =>
-                             (!onlyErrors || result.Level == "error") && !result.Suppressions.Any()))
+                             (!onlyErrors || result.Level == "error") && !(result.Suppressions != null && result.Suppressions.Any())))
                 {
                     sb.Append(CreateResultInfo(result, tool));
                 }

--- a/sarif-to-markdown.csx
+++ b/sarif-to-markdown.csx
@@ -93,14 +93,9 @@ void CreateResult(string filePath, StringBuilder sb, string fileName, ICollectio
             foreach (var run in securityScan.Runs)
             {
                 var tool = securityScan.Runs.FirstOrDefault()?.Tool;
-                foreach (var result in run.Results)
+                foreach (var result in run.Results.Where(result =>
+                             (!onlyErrors || result.Level == "error") && !result.Suppressions.Any()))
                 {
-                    if (onlyErrors)
-                    {
-                        if (result.Level != "error")
-                            continue;
-                    }
-
                     sb.Append(CreateResultInfo(result, tool));
                 }
             }
@@ -127,7 +122,7 @@ bool ShouldProcess(bool onlyErrors, SecurityScan securityScan1)
 
     return !onlyErrors
         ? runs.Any(run => run.Results.Any())
-        : runs.Any(run => run.Results.Any(result => result.Level == "error"));
+        : runs.Any(run => run.Results.Any(result => result.Level == "error" && !result.Suppressions.Any()));
 }
 
 string CreateResultInfo(Result result, Tool tool)
@@ -195,6 +190,9 @@ public class Result
     [JsonPropertyName("locations")]
     public List<Location> Locations { get; set; }
 
+    [JsonPropertyName("suppressions")]
+    public List<Suppression> Suppressions { get; set; }
+
     [JsonPropertyName("properties")]
     public ResultProperties Properties { get; set; }
 
@@ -206,6 +204,15 @@ public class Location
 {
     [JsonPropertyName("physicalLocation")]
     public PhysicalLocation PhysicalLocation { get; set; }
+}
+
+public class Suppression
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; set; }
+
+    [JsonPropertyName("justification")]
+    public string Justification { get; set; }
 }
 
 public class PhysicalLocation


### PR DESCRIPTION
dotnet builds still add errors to ErrorLog.sarif even if there's a suppression rule. This suppression is added to the JSON, so if there's an error but with a suppression, do not list it as an error in the report.