### PR TITLE
pin dotnet-script to v 1.3.1 so dotnet core 3.1 is still supported

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - run: dotnet tool install --global security-scan
       shell: bash
-    - run: dotnet tool install --global dotnet-script
+    - run: dotnet tool install --global dotnet-script --version 1.3.1
       shell: bash
     - run: find . -name "*.sln" -exec dotnet build {} /p:ErrorLog="ErrorLog.sarif%2Cversion=2.1" \;
       shell: bash


### PR DESCRIPTION
latest version >= 1.4.0 is not compatible with dotnet core 3.1

```
Run dotnet tool install --global dotnet-script
  dotnet tool install --global dotnet-script
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    DOTNET_ROOT: C:\Users\runneradmin\AppData\Local\Microsoft\dotnet
error NU1202: Package dotnet-script 1.4.0 is not compatible with netcoreapp3.1 (.NETCoreApp,Version=v3.1) / any. Package dotnet-script 1.4.0 supports:
error NU1202:   - net6.0 (.NETCoreApp,Version=v6.0) / any
error NU1202:   - net7.0 (.NETCoreApp,Version=v7.0) / any
```